### PR TITLE
[update]ジュースリストをVendingMachineインスタンス移行、メソッド共通化

### DIFF
--- a/lib/User.rb
+++ b/lib/User.rb
@@ -1,8 +1,4 @@
 class User
-  # VendingMachineクラスで追加されたジュースの名前と価格が入る
-  CHOICE_JUICE = ["キャンセル"]
-  JUICE_PRICE = []
-
   def initialize(name: 'taro')
     @name = name
   end
@@ -19,8 +15,8 @@ class User
     puts "投入金額と在庫から買えるのは以下の飲み物です"
     # ストックの数だけforで表示する
     for i in 0..machine.stock.count - 1 do
-      if machine.current_slot_money >= JUICE_PRICE[i] && !machine.stock[CHOICE_JUICE[i]].empty?
-        puts "#{CHOICE_JUICE[i]}"
+      if machine.current_slot_money >= machine.juice_price_list[i] && !machine.stock[machine.juice_name_list[i]].empty?
+        puts "#{machine.juice_name_list[i]}"
         puts
       end
     end
@@ -31,19 +27,19 @@ class User
     puts "投入金額:#{machine.current_slot_money}円"
     # 定数から繰り返し回数を判定
     for i in 0..machine.stock.count - 1 do
-      puts "#{i}: #{CHOICE_JUICE[i]}:#{JUICE_PRICE[i]}円"
+      puts "#{i}: #{machine.juice_name_list[i]}:#{machine.juice_price_list[i]}円"
       puts
     end
-    puts "#{CHOICE_JUICE.index("キャンセル")}: キャンセル"
+    puts "#{machine.juice_name_list.index("キャンセル")}: キャンセル"
     puts "数字を入力してください"
 
     choice_number = Integer(gets.chomp) rescue nil
 
     # 不正な入力判定
-    if choice_number == nil || CHOICE_JUICE[choice_number].nil?
-      puts "0~#{CHOICE_JUICE.count - 1}のみで入力してください。"
+    if choice_number == nil || machine.juice_name_list[choice_number].nil?
+      puts "0~#{machine.juice_name_list.count - 1}のみで入力してください。"
       choice(machine)
-    elsif CHOICE_JUICE[choice_number] == "キャンセル"
+    elsif machine.juice_name_list[choice_number] == "キャンセル"
       puts "キャンセルしました"
       machine.return_money
     else

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require './lib/VendingMachine'
+require './lib/Juice'
+require './lib/User'
+
+class VendingMachineTest < Minitest::Test
+  def test_new_user
+    user = User.new
+    assert_equal user.name, 'taro'
+  end
+end


### PR DESCRIPTION
改善点は以下２点です。
・元々Userクラスにあった定数を自販機オブジェクトにjuice_name_listとjuice_price_list属性として追加し、自販機オブジェクトが複数できても各オブジェクトごとにリストを所持することが可能に。
・VendingMachineオブジェクトにjuiceインスタンスを投入する際のメソッド処理をjuice_insert_first?メソッド導入による共通化
基本的な動作の変更はありませんのでご確認ください。